### PR TITLE
multi-target netstandard2.1 and net5.0; add bunit tests

### DIFF
--- a/Functional.Blazor.Components.Tests/Functional.Blazor.Components.Tests.csproj
+++ b/Functional.Blazor.Components.Tests/Functional.Blazor.Components.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="1.0.0-preview-01" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Functional.Blazor.Components\Functional.Blazor.Components.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Functional.Blazor.Components.Tests/OptionMatchAsyncTests.cs
+++ b/Functional.Blazor.Components.Tests/OptionMatchAsyncTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Xunit;
+
+namespace Functional.Blazor.Components.Tests
+{
+	public class OptionMatchAsyncTests
+	{
+		private const string LOADING = "loading...";
+		private const string VALUE = "the option holds a value";
+		private const string NO_VALUE = "the option does not hold a value";
+
+		[Fact]
+		public void DisplaysLoadingWhenOptionTaskNotComplete()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<OptionMatchAsync<string>>(parameters => parameters
+				.Add(c => c.Option, new Task<Option<string>>(() => Option.Some(VALUE)))
+				.Add(c => c.Loading, $"<p>{LOADING}</p>")
+				.Add(c => c.Some, s => $"<p>{s}</p>")
+				.Add(c => c.None, $"<p>{NO_VALUE}</p>"));
+
+			cut.Markup.Should().Contain(LOADING);
+		}
+
+		[Fact]
+		public void DisplaysValueWhenOptionTaskIsCompleteAndOptionHasValue()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<OptionMatchAsync<string>>(parameters => parameters
+				.Add(c => c.Option, Task.FromResult(Option.Some(VALUE)))
+				.Add(c => c.Loading, $"<p>{LOADING}</p>")
+				.Add(c => c.Some, s => $"<p>{s}</p>")
+				.Add(c => c.None, $"<p>{NO_VALUE}</p>"));
+
+			cut.Markup.Should().Contain(VALUE);
+		}
+
+		[Fact]
+		public void DisplaysFallbackWhenOptionTaskIsCompleteAndOptionHasNoValue()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<OptionMatchAsync<string>>(parameters => parameters
+				.Add(c => c.Option, Task.FromResult(Option.None<string>()))
+				.Add(c => c.Loading, $"<p>{LOADING}</p>")
+				.Add(c => c.Some, s => $"<p>{s}</p>")
+				.Add(c => c.None, $"<p>{NO_VALUE}</p>"));
+
+			cut.Markup.Should().Contain(NO_VALUE);
+		}
+	}
+}

--- a/Functional.Blazor.Components.Tests/OptionMatchTests.cs
+++ b/Functional.Blazor.Components.Tests/OptionMatchTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Bunit;
+using FluentAssertions;
+using Xunit;
+
+namespace Functional.Blazor.Components.Tests
+{
+	public class OptionMatchTests
+	{
+		private const string VALUE = "the option holds a value";
+		private const string NO_VALUE = "the option does not hold a value";
+
+		[Fact]
+		public void DisplaysValueWhenOptionHasValue()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<OptionMatch<string>>(parameters => parameters
+				.Add(c => c.Option, Option.Some(VALUE))
+				.Add(c => c.Some, s => $"<p>{s}</p>")
+				.Add(c => c.None, $"<p>{NO_VALUE}</p>"));
+
+			cut.Markup.Should().Contain(VALUE);
+		}
+
+		[Fact]
+		public void DisplaysFallbackWhenOptionHasNoValue()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<OptionMatch<string>>(parameters => parameters
+				.Add(c => c.Option, Option.None<string>())
+				.Add(c => c.Some, s => $"<p>{s}</p>")
+				.Add(c => c.None, $"<p>{NO_VALUE}</p>"));
+
+			cut.Markup.Should().Contain(NO_VALUE);
+		}
+	}
+}

--- a/Functional.Blazor.Components.Tests/ResultMatchAsyncTests.cs
+++ b/Functional.Blazor.Components.Tests/ResultMatchAsyncTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Xunit;
+
+namespace Functional.Blazor.Components.Tests
+{
+	public class ResultMatchAsyncTests
+	{
+		private const string LOADING = "loading...";
+		private const int SUCCESS = 1337;
+		private const string FAILURE = "error";
+
+		[Fact]
+		public void DisplaysSuccessValueWhenResultTaskIsNotComplete()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<ResultMatchAsync<int, string>>(parameters => parameters
+				.Add(c => c.Result, new Task<Result<int, string>>(() => Result.Success<int, string>(SUCCESS)))
+				.Add(c => c.Loading, $"<p>{LOADING}</p>")
+				.Add(c => c.Success, i => $"<p>{i}</p>")
+				.Add(c => c.Failure, s => $"<p>{s}</p>"));
+
+			cut.Markup.Should().Contain(LOADING);
+		}
+
+		[Fact]
+		public void DisplaysSuccessValueWhenResultTaskIsCompleteAndResultIsSuccess()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<ResultMatchAsync<int, string>>(parameters => parameters
+				.Add(c => c.Result, Task.FromResult(Result.Success<int, string>(SUCCESS)))
+				.Add(c => c.Loading, $"<p>{LOADING}</p>")
+				.Add(c => c.Success, i => $"<p>{i}</p>")
+				.Add(c => c.Failure, s => $"<p>{s}</p>"));
+
+			cut.Markup.Should().Contain(SUCCESS.ToString());
+		}
+
+		[Fact]
+		public void DisplaysFailureValueWhenResultTaskIsCompleteAndResultIsFaulted()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<ResultMatchAsync<int, string>>(parameters => parameters
+				.Add(c => c.Result, Task.FromResult(Result.Failure<int, string>(FAILURE)))
+				.Add(c => c.Loading, $"<p>{LOADING}</p>")
+				.Add(c => c.Success, i => $"<p>{i}</p>")
+				.Add(c => c.Failure, s => $"<p>{s}</p>"));
+
+			cut.Markup.Should().Contain(FAILURE);
+		}
+	}
+}

--- a/Functional.Blazor.Components.Tests/ResultMatchTests.cs
+++ b/Functional.Blazor.Components.Tests/ResultMatchTests.cs
@@ -1,0 +1,36 @@
+﻿using Bunit;
+using FluentAssertions;
+using Xunit;
+
+namespace Functional.Blazor.Components.Tests
+{
+	public class ResultMatchTests
+	{
+		private const int SUCCESS = 1337;
+		private const string FAILURE = "error";
+
+		[Fact]
+		public void DisplaysSuccessValueWhenResultIsSuccess()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<ResultMatch<int, string>>(parameters => parameters
+				.Add(c => c.Result, Result.Success<int, string>(SUCCESS))
+				.Add(c => c.Success, i => $"<p>{i}</p>")
+				.Add(c => c.Failure, s => $"<p>{s}</p>"));
+
+			cut.Markup.Should().Contain(SUCCESS.ToString());
+		}
+
+		[Fact]
+		public void DisplaysFailureValueWhenResultIsFaulted()
+		{
+			using var context = new TestContext();
+			var cut = context.RenderComponent<ResultMatch<int, string>>(parameters => parameters
+				.Add(c => c.Result, Result.Failure<int, string>(FAILURE))
+				.Add(c => c.Success, i => $"<p>{i}</p>")
+				.Add(c => c.Failure, s => $"<p>{s}</p>"));
+
+			cut.Markup.Should().Contain(FAILURE);
+		}
+	}
+}

--- a/Functional.Blazor.Components/Functional.Blazor.Components.csproj
+++ b/Functional.Blazor.Components/Functional.Blazor.Components.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
-    <Authors>Justin Cooney</Authors>
-    <Description>A collection of Blazor Component for the C# Functional library</Description>
+    <Authors>Justin Cooney + contributors</Authors>
+    <Description>A collection of Blazor components for the C# Functional library</Description>
     <PackageProjectUrl>https://functionalblazor.z13.web.core.windows.net/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Justin-Cooney/Functional.Blazor</RepositoryUrl>
 	<Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">0.0.1-local</Version>

--- a/Functional.Blazor.Components/Functional.Blazor.Components.csproj
+++ b/Functional.Blazor.Components/Functional.Blazor.Components.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
     <Authors>Justin Cooney</Authors>
     <Description>A collection of Blazor Component for the C# Functional library</Description>
@@ -14,8 +14,14 @@
 
   <ItemGroup>
     <PackageReference Include="Functional.Primitives" Version="2.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+	<PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.4" />
+	<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+	<PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.2" />
+	<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.2" />
   </ItemGroup>
 
 

--- a/Functional.Blazor.sln
+++ b/Functional.Blazor.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functional.Blazor.Component
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functional.Blazor.ExampleApp", "Functional.Blazor.ExampleApp\Functional.Blazor.ExampleApp.csproj", "{1B50C4E7-7F7B-4033-AA7E-D3C93D367257}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functional.Blazor.Components.Tests", "Functional.Blazor.Components.Tests\Functional.Blazor.Components.Tests.csproj", "{24FB9E88-740E-4149-8D07-69A0E4568673}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{1B50C4E7-7F7B-4033-AA7E-D3C93D367257}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1B50C4E7-7F7B-4033-AA7E-D3C93D367257}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1B50C4E7-7F7B-4033-AA7E-D3C93D367257}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24FB9E88-740E-4149-8D07-69A0E4568673}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24FB9E88-740E-4149-8D07-69A0E4568673}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24FB9E88-740E-4149-8D07-69A0E4568673}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24FB9E88-740E-4149-8D07-69A0E4568673}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- modifies `Functional.Blazor.Components` project to multi-target `netstandard2.1` and `net5.0` (the `net5.0` package will use latest version of `Microsoft.AspNetCore.Components` and `Microsoft.AspNetCore.Components.Web` packages)
- adds `Functional.Blazor.Components.Tests` project; [uses `bunit` for Blazor component tests](https://github.com/egil/bunit)